### PR TITLE
Deactivate screensaver on SDL2

### DIFF
--- a/Source/OpenTK/Platform/SDL2/Sdl2.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2.cs
@@ -295,6 +295,10 @@ namespace OpenTK.Platform.SDL2
         public static extern void HideWindow(IntPtr window);
 
         [SuppressUnmanagedCodeSecurity]
+        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_DisableScreenSaver", ExactSpelling = true)]
+        public static extern void DisableScreenSaver();
+
+        [SuppressUnmanagedCodeSecurity]
         [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_Init", ExactSpelling = true)]
         public static extern int Init(SystemFlags flags);
 

--- a/Source/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
@@ -75,6 +75,8 @@ namespace OpenTK.Platform.SDL2
         {
             lock (sync)
             {
+                SDL.DisableScreenSaver();
+
                 var bounds = device.Bounds;
                 var flags = TranslateFlags(options);
                 flags |= WindowFlags.OPENGL;


### PR DESCRIPTION
This implements SDL_DisableScreenSaver to avoid having screensaver when playing with a gamepad.
