### PR TITLE
Fix SDL2 instance enumeration and mapping

### DIFF
--- a/Source/OpenTK/Platform/SDL2/Sdl2.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2.cs
@@ -336,6 +336,10 @@ namespace OpenTK.Platform.SDL2
         public static extern JoystickGuid JoystickGetGUID(IntPtr joystick);
 
         [SuppressUnmanagedCodeSecurity]
+        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_JoystickInstanceID", ExactSpelling = true)]
+        public static extern int JoystickInstanceID(IntPtr joystick);
+
+        [SuppressUnmanagedCodeSecurity]
         [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_JoystickName", ExactSpelling = true)]
         static extern IntPtr JoystickNameInternal(IntPtr joystick);
         public static string JoystickName(IntPtr joystick)

--- a/Source/OpenTK/Platform/SDL2/Sdl2JoystickDriver.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2JoystickDriver.cs
@@ -42,6 +42,7 @@ namespace OpenTK.Platform.SDL2
         {
             public IntPtr Handle { get; set; }
             public Guid Guid { get; set; }
+            public int InstanceId { get; set; }
             public int PacketNumber { get; set; }
             public int HatCount { get; set; }
             public int BallCount { get; set; }
@@ -51,7 +52,6 @@ namespace OpenTK.Platform.SDL2
         }
 
         // For IJoystickDriver2 implementation
-        int last_joystick_instance = 0;
         readonly List<JoystickDevice> joysticks = new List<JoystickDevice>(4);
         readonly Dictionary<int, int> sdl_instanceid_to_joysticks = new Dictionary<int, int>();
 
@@ -98,6 +98,7 @@ namespace OpenTK.Platform.SDL2
                 joystick = new JoystickDevice<Sdl2JoystickDetails>(id, num_axes, num_buttons);
                 joystick.Description = SDL.JoystickName(handle);
                 joystick.Details.Handle = handle;
+                joystick.Details.InstanceId = SDL.JoystickInstanceID(handle);
                 joystick.Details.Guid = SDL.JoystickGetGUID(handle).ToGuid();
                 joystick.Details.HatCount = num_hats;
                 joystick.Details.BallCount = num_balls;
@@ -315,11 +316,12 @@ namespace OpenTK.Platform.SDL2
                     {
                         IntPtr handle = SDL.JoystickOpen(id);
                         if (handle != IntPtr.Zero)
-                        {
-                            int device_id = id;
-                            int instance_id = last_joystick_instance++;
-
+                        {                                                        
                             JoystickDevice<Sdl2JoystickDetails> joystick = OpenJoystick(id);
+
+                            int instance_id = joystick.Details.InstanceId;
+                            int device_id = id;
+
                             if (joystick != null)
                             {
                                 joystick.Details.IsConnected = true;


### PR DESCRIPTION
OpenTK was not using SDL2 joystick's instance IDs to populate its joystick list. This was making the initial joystick initialization to be totally random and could make the input mappings to be random as well if gamepads of different brands are used at the same time (because the GUID were getting shuffled).

Fixes mono/MonoGame#4566

@dellis1972 @cra0zy @tomspilman 
